### PR TITLE
Fix bad units in call to pvlib.pvsystem.sapm

### DIFF
--- a/pvmismatch/contrib/gen_coeffs/__init__.py
+++ b/pvmismatch/contrib/gen_coeffs/__init__.py
@@ -24,7 +24,8 @@ def gen_iec_61853_from_sapm(pvmodule):
     Module is a dictionary according to ``pvlib.pvsystem.sapm``.
     """
     tc, irr = TEST_MAT
-    return sapm(irr / 1000.0, tc, pvmodule)
+    # sapm in pvlib.pvsystem expects effective_irradiance in W/m2, temp_cell in degrees Celsius
+    return sapm(irr, tc, pvmodule)
 
 
 def gen_two_diode(isc, voc, imp, vmp, nseries, nparallel,


### PR DESCRIPTION
pvlib.pvsystem.sapm expects the irradiance in W/m2 so the irradiance values from `TEST_MAT` do *not* need to be divided by 1,000.

This should fix a failed assertion in `example.py` at line 33.